### PR TITLE
Explict open of README.md as utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
 except(IOError, ImportError):
-    long_description = open('README.md').read()
+    long_description = open('README.md', encoding='utf8').read()
 
 setup(
     name='meraki',


### PR DESCRIPTION
Fixes issue in Windows when running `python setup install`

Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    long_description = open('README.md').read()
  File "C:\Python\Python37\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3153: character maps to <undefined>